### PR TITLE
Add Cathie Yun as author of the Fiat-Shamir specification

### DIFF
--- a/draft-irtf-cfrg-fiat-shamir.md
+++ b/draft-irtf-cfrg-fiat-shamir.md
@@ -26,6 +26,10 @@ author:
     fullname: "Michele Orrù"
     organization: CNRS
     email: "m@orru.net"
+-
+    fullname: "Cathie Yun"
+    organization: Apple, Inc.
+    email: "cathieyun@gmail.com"
 
 normative:
 


### PR DESCRIPTION
This reverts commit 935cbfd59ef93ea11513dcbf6caca4e3d50b7f92 and re-instates Cathie Yun as a spec author.

@cathieyun once you get approval, feel free to merge this. 
