### PR TITLE
Update pseudocode style in document

### DIFF
--- a/draft-irtf-cfrg-fiat-shamir.md
+++ b/draft-irtf-cfrg-fiat-shamir.md
@@ -294,6 +294,8 @@ Note that the prover does not need to compute the last verifier message `verifie
 
 The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**NOT RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}} when, and only when, they appear in all capitals, as shown here.
 
+The algorithms and procedures in this document are specified using Python-like pseudocode. Each function accepts defined inputs and parameters and returns one or more output values. Once a protocol variant and ciphersuite are selected, all associated parameters are treated as constants.
+
 The following notation is used throughout this document.
 
 ## Bytes and integers

--- a/draft-irtf-cfrg-sigma-protocols.md
+++ b/draft-irtf-cfrg-sigma-protocols.md
@@ -338,6 +338,8 @@ Sigma Protocols can compose: several statements can be proven simultaneously (AN
 
 The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**NOT RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}} when, and only when, they appear in all capitals, as shown here.
 
+The algorithms and procedures in this document are specified using Python-like pseudocode. Each function accepts defined inputs and parameters and returns one or more output values. Once a protocol variant and ciphersuite are selected, all associated parameters are treated as constants.
+
 The following notation is used throughout this document.
 
 ## Bytes and integers {#bytes-and-integers}


### PR DESCRIPTION
Since much of the pseudocode in the document is written in a Python-like style, a statement clarifying this should be added.