### PR TITLE
Minor editorial nits for new version release

### DIFF
--- a/draft-irtf-cfrg-sigma-protocols.md
+++ b/draft-irtf-cfrg-sigma-protocols.md
@@ -1258,7 +1258,7 @@ NargString =
 Expected = accept
 ~~~
 
-Knowledge of the opening of a Pedersen commitment, `C = x * G + r * H`
+Knowledge of the opening of a Pedersen commitment, `C = m * G + r * H`
 ({{relation-notation}}).
 
 ~~~
@@ -1289,7 +1289,7 @@ NargString =
 Expected = accept
 ~~~
 
-Knowledge of the opening of a Pedersen commitment, `C = x * G + r * H`
+Knowledge of the opening of a Pedersen commitment, `C = m * G + r * H`
 ({{relation-notation}}).
 
 ~~~
@@ -2471,7 +2471,7 @@ NargString =
 Expected = accept
 ~~~
 
-Knowledge of the opening of a Pedersen commitment, `C = x * G + r * H`
+Knowledge of the opening of a Pedersen commitment, `C = m * G + r * H`
 ({{relation-notation}}).
 
 ~~~
@@ -2502,7 +2502,7 @@ NargString =
 Expected = accept
 ~~~
 
-Knowledge of the opening of a Pedersen commitment, `C = x * G + r * H`
+Knowledge of the opening of a Pedersen commitment, `C = m * G + r * H`
 ({{relation-notation}}).
 
 ~~~

--- a/draft-irtf-cfrg-sigma-protocols.md
+++ b/draft-irtf-cfrg-sigma-protocols.md
@@ -362,7 +362,7 @@ Group elements are upper-case (`G`, `X`, `M`) and scalars lower-case (`x`, `s`).
 
 `identity()` is the neutral element, `generator()` returns the canonical generator of the prime-order subgroup ({{ciphersuites}}), and `order()` returns its order `p`. Addition, negation, equality, and scalar multiplication by a `Scalar` are written `+`, `-`, `==`, and `*`.
 
-`serialize(elements: [Group; N])` and `deserialize(buffer)` convert `N` non-neutral group elements into a fixed-length `Ne * N`-byte encoding, where `Ne` is fixed per ciphersuite ({{ciphersuites}}).
+`serialize(elements: list[Group])` and `deserialize(buffer)` convert `N` non-neutral group elements into a fixed-length `Ne * N`-byte encoding, where `Ne` is fixed per ciphersuite ({{ciphersuites}}).
 
 Both `serialize` and `deserialize` are defined only on non-neutral elements. Serialization **MUST** fail on the identity element, and deserialization **MUST** fail for invalid encodings, including on the encoding of the identity. An honest prover statistically hits this event only with negligible probability. See {{Section 10.1 of RFC9380}}, Appendix C of {{PAIRING}}, {{Section 2.1 of ?RFC9497}}, {{ARC}}.
 
@@ -370,7 +370,7 @@ Both `serialize` and `deserialize` are defined only on non-neutral elements. Ser
 
 A `Scalar` is an element of the group's *scalar field*, the prime field of integers modulo the group order `p`. Addition and multiplication are written `+` and `*` via operator overloading.
 
-`serialize(scalars: list[Scalar; N])` and `deserialize(buffer)` batch convert between `[Scalar; N]` and its canonical, fixed-length `Ns * N`-byte encoding.
+`serialize(scalars: list[Scalar])` and `deserialize(buffer)` batch convert between `N` scalars and their canonical, fixed-length `Ns * N`-byte encoding.
 
 Sampling a random scalar takes two steps: obtaining high-quality entropy via a CSPRNG (e.g., `getrandom()`; see {{?RFC4086}} for randomness requirements), and reducing the resulting bytes to a scalar. It is **RECOMMENDED** that the latter be done via `DecodeField` as in {{fiat-shamir}}. Different sampling mechanisms, such as the wide reduction of `hash_to_field` ({{Section 5.2 of ?RFC9380}}) and the integer conversion of Appendix A.4.1 of {{FIPS186-5}} do not affect interoperability of proofs. The "discard method" of Appendix A.4.2 of {{FIPS186-5}} **SHOULD NOT** be used {{constant-time}}.
 


### PR DESCRIPTION
Fix minor consistency issues in the draft:

- consistent witness name between the prose and the relation pseudocode.
- consistent function type signature, as the draft currently mixes Rust and Python syntax.