### PR TITLE
Cite Brands on linear-relation proofs

### DIFF
--- a/draft-irtf-cfrg-sigma-protocols.md
+++ b/draft-irtf-cfrg-sigma-protocols.md
@@ -163,6 +163,12 @@ informative:
     date: 1997
     author:
       - fullname: "Ronald Cramer"
+  Brands00:
+    title: "Rethinking Public Key Infrastructures and Digital Certificates: Building in Privacy"
+    target: https://www.credentica.com/mit/Chapter3.pdf
+    date: 2000
+    author:
+      - fullname: "Stefan Brands"
   Maurer09:
     title: "Unifying Zero-Knowledge Proofs of Knowledge"
     target: https://doi.org/10.1007/978-3-642-02384-2_17
@@ -304,7 +310,7 @@ Examples include zero-knowledge proofs for discrete logarithm relations, ElGamal
 
 Zero-knowledge proofs of knowledge allow a prover to convince a verifier that a statement is true, without revealing anything other than what is already revealed by the statement itself.
 
-Sigma Protocols are an essential component of a number of cryptographic constructions, such as anonymous credentials {{ARC}} {{BBS}}, verifiable random functions {{?RFC9381}}, anonymous tokens {{?RFC9497}}, blind signatures {{BBSBlind}}, and proofs of knowledge of the opening of a Pedersen commitment {{Pedersen91}}. This document specifies a single Sigma Protocol for proving knowledge of a preimage of a linear map over a prime-order group {{Cramer97}} {{Maurer09}}. A *linear relation* is a system of equations among group elements that is linear in the secret scalars; affine relations with constant terms (e.g. verifiable encryption) and quadratic equations (e.g. range proofs) can also be expressed as the preimage of a linear map ({{linear-map}}).
+Sigma Protocols are an essential component of a number of cryptographic constructions, such as anonymous credentials {{ARC}} {{BBS}}, verifiable random functions {{?RFC9381}}, anonymous tokens {{?RFC9497}}, blind signatures {{BBSBlind}}, and proofs of knowledge of the opening of a Pedersen commitment {{Pedersen91}}. This document specifies a single Sigma Protocol for proving knowledge of a preimage of a linear map over a prime-order group {{Brands00}}, {{Cramer97}}, {{Maurer09}}. A *linear relation* is a system of equations among group elements that is linear in the secret scalars; affine relations with constant terms (e.g. verifiable encryption) and quadratic equations (e.g. range proofs) can also be expressed as the preimage of a linear map ({{linear-map}}).
 
 A Sigma Protocol is an interactive proof with the following three-message flow:
 


### PR DESCRIPTION
> The core prime-order linear-relation Sigma protocol in the draft is, algebraically, precisely the generalized representation-proof technique that [Brands] introduced in my work in the early 1990s. In multiplicative notation, your relation consists of equations of the form Y\_i = product\_j G\_ij^(x\_j). The prover forms the corresponding commitment equations using random exponents r\_j, receives a challenge c, responds with z\_j = r\_j + c x\_j, and the verifier checks the same linear map on the response vector, equivalently product\_j G\_ij^(z\_j) = A\_i Y\_i^c. This is exactly the DL-representation proof machinery underlying Brands linear-relation techniques. The technique for proving a linear relation among the secret coordinates of a DL representation was already part of Brands work filed in August 1993 as “Privacy-Protected Transfer of Electronic Information.” I subsequently developed the general machinery for efficiently proving Boolean combinations of such linear relations, published as “Rapid Demonstration of Linear Relations Connected by Boolean Operators” at EUROCRYPT ’97.
>
> A convenient consolidated reference is my 2000 MIT Press book, “Rethinking Public Key Infrastructures and Digital Certificates: Building in Privacy.” Section 3.3 (see, e.g., [www.credentica.com/mit/Chapter3.pdf](http://www.credentica.com/mit/Chapter3.pdf)) gives the general treatment of systems of linear relations over the secret coordinates of a DL representation. The bibliographic notes explicitly trace the single-linear-relation technique back to my 1993 work and the general Boolean machinery to my subsequent work.
